### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # Policy Server Guide Content
-Guide content for the [SDL Developer Portal](https://smartdevicelink.com/guides/sdl-server/getting-started/).
+Guide content for the [SDL Developer Portal](https://smartdevicelink.com/en/guides/sdl-server/overview/).
 
 ## How to Use This Guide
 


### PR DESCRIPTION
Current: 
>Guide content for the `SDL Developer Portal` links to a broken link: https://smartdevicelink.com/guides/sdl-server/getting-started/.

Expected: 
>Guide content for the `SDL Developer Portal` links to https://smartdevicelink.com/en/guides/sdl-server/overview/.