### PR TITLE
Fix incorrect links

### DIFF
--- a/docs/API Reference Documentation/Policy Table/Module Config/index.md
+++ b/docs/API Reference Documentation/Policy Table/Module Config/index.md
@@ -16,7 +16,7 @@ There is a limit for the number of notifications that can be displayed per prior
 <a name="Policy-Table-Update-Configurations"></a>
 
 ## Policy Table Update Configurations
-Periodically changes will be made to a Policy Table, either by the Policy Server or SDL Core. This means SDL Core should check for and perform a [Policy Table update](/docs/sdl-server/policy-table-update), which synchronizes the local and Policy Server Policy Tables. You can configure when SDL Core will check using the following configurations.
+Periodically changes will be made to a Policy Table, either by the Policy Server or SDL Core. This means SDL Core should check for and perform a [Policy Table update](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table-update/), which synchronizes the local and Policy Server Policy Tables. You can configure when SDL Core will check using the following configurations.
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |

--- a/docs/API Reference Documentation/index.md
+++ b/docs/API Reference Documentation/index.md
@@ -359,7 +359,7 @@ There is a limit for the number of notifications that can be displayed per prior
 <a name="Policy-Table-Update-Configurations"></a>
 
 ## Policy Table Update Configurations
-Periodically changes will be made to a Policy Table, either by the Policy Server or SDL Core. This means SDL Core should check for and perform a [Policy Table update](https://smartdevicelink.com/en/guides/sdl-server/getting-started/server-update/), which synchronizes the local and Policy Server Policy Tables. You can configure when SDL Core will check using the following configurations.
+Periodically changes will be made to a Policy Table, either by the Policy Server or SDL Core. This means SDL Core should check for and perform a [Policy Table update](https://smartdevicelink.com/en/guides/sdl-server/api-reference-documentation/policy-table-update/), which synchronizes the local and Policy Server Policy Tables. You can configure when SDL Core will check using the following configurations.
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |


### PR DESCRIPTION
There was a relative link that doesn't work that is now fixed, and an absolute link that pointed to the wrong page that is now corrected.